### PR TITLE
 chore: analyzer exclude for tools and ignore embedded SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@
 .history
 
 
+# Local tooling (embedded SDKs)
+tools/
+
+
 
 # Flutter repo-specific
 /bin/cache/

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -32,3 +32,5 @@ analyzer:
   exclude:
     - "**/*.g.dart"
     - "**/*.freezed.dart"
+  # Exclude local tooling and embedded SDKs from analysis
+  - "tools/**"


### PR DESCRIPTION
  - Summary
    - Exclude tools/** from analyzer to avoid scanning embedded SDK
    - Add tools/ to .gitignore to prevent committing local Flutter SDK
  - Changes
    - analysis_options.yaml: add tools/** to analyzer.exclude
    - .gitignore: add tools/
  - Tests
    - flutter analyze lib test → No issues
    - flutter test → All passed
  - Notes
    - No runtime behavior change
  - Checklist
    - [x] Lint/Test pass
    - [x] No breaking change